### PR TITLE
Use different database names for release and debug builds

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:frigoligo/providers/article.dart';
 import 'package:frigoligo/wallabag/wallabag.dart';
@@ -61,7 +62,7 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
-      future: Future.wait([DB.init(), WallabagInstance.init()]),
+      future: Future.wait([DB.init(kDebugMode), WallabagInstance.init()]),
       builder: (context, snapshot) {
         if (snapshot.hasData) {
           return WallabagInstance.isReady

--- a/lib/models/db.dart
+++ b/lib/models/db.dart
@@ -13,13 +13,14 @@ class DB {
   static Isar? _instance;
   static final List<LogRecord> _earlyLogs = [];
 
-  static Future<void> init() async {
+  static Future<void> init(bool devmode) async {
     if (_instance != null) return;
 
     final dir = await getApplicationDocumentsDirectory();
     _instance = await Isar.open(
       [AppLogSchema, ArticleSchema, ArticleScrollPositionSchema],
       directory: dir.path,
+      name: 'frigoligo${devmode ? '-dev' : ''}',
     );
     _prepareAppLogs();
   }


### PR DESCRIPTION
Allow to run both with a dedicated DB.