### PR TITLE
Allow to sign debug version alongside release version for android

### DIFF
--- a/.github/workflows/upload_to_playstore.yml
+++ b/.github/workflows/upload_to_playstore.yml
@@ -28,6 +28,8 @@ jobs:
       - run: flutter --version
       - run: flutter pub get
       - run: flutter build appbundle
+        env:
+          NO_SIGNING: true
       - name: Sign Release
         uses: r0adkll/sign-android-release@v1
         id: sign_release

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,7 +44,6 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "net.casimirlab.frigoligo"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
@@ -56,7 +55,7 @@ android {
 
     buildTypes {
         release {
-            signingConfig null
+            signingConfig System.getenv('NO_SIGNING') != null ? null : signingConfigs.debug
         }
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.4.0+4
+version: 0.4.1+1
 
 environment:
   sdk: ">=3.0.5 <4.0.0"


### PR DESCRIPTION
Adresses #56 without breaking the playstore release build.