### PR TITLE
Add a few deeplinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,41 @@ A full history of changes is available in [CHANGELOG.md](./CHANGELOG.md).
 |:-:|:-:|:-:|
 |![android screenshot](./assets/screenshots/android_light.png)|![desktop screenshot](./assets/screenshots/desktop.png)|![android dark theme screenshot](./assets/screenshots/android_dark.png)|
 
+## Deeplinks
+
+Frigoligo supports a few deeplinks that allows it to be integrated in external workflows. All platforms except Linux are supported.
+
+### Links format
+
+Deeplinks are based on a custom scheme, the URI path is used to determine the action to perform.
+
+The follow link will open the app and perform the `action` action with the given parameters `param1` (`hello`) and `param2` (`Günther`). Note that the host `x` is just here for readability and is ignored.
+```
+frigoligo://x/action?param1=hello&param2=G%C3%BCnther
+```
+
+### Actions
+
+#### `/login`
+
+Open the login page and prefills the given credentials. Be aware that such link in the wild weakens the security of your account.
+
+| Parameter      | Description                  | Required |
+|----------------|------------------------------|----------|
+| `server`       | Your Wallabag server URL.    | No       |
+| `clientId`     | Your Wallabag client ID.     | No       |
+| `clientSecret` | Your Wallabag client secret. | No       |
+| `username`     | Your Wallabag username.      | No       |
+| `password`     | Your Wallabag password.      | No       |
+
+#### `/save`
+
+Save a new article. This is super useful to integrate article saving from an external workflow.
+
+| Parameter | Description                     | Required |
+|-----------|---------------------------------|----------|
+| `url`     | The URL of the article to save. | Yes      |
+
 ## License
 
 Licensed under the MIT. See [LICENSE](./LICENSE) for details.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleInstance"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,6 @@
 PODS:
+  - app_links (0.0.1):
+    - Flutter
   - Flutter (1.0.0)
   - flutter_app_badger (1.3.0):
     - Flutter
@@ -24,6 +26,7 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
+  - app_links (from `.symlinks/plugins/app_links/ios`)
   - Flutter (from `Flutter`)
   - flutter_app_badger (from `.symlinks/plugins/flutter_app_badger/ios`)
   - isar_flutter_libs (from `.symlinks/plugins/isar_flutter_libs/ios`)
@@ -39,6 +42,8 @@ SPEC REPOS:
     - FMDB
 
 EXTERNAL SOURCES:
+  app_links:
+    :path: ".symlinks/plugins/app_links/ios"
   Flutter:
     :path: Flutter
   flutter_app_badger:
@@ -59,6 +64,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
+  app_links: 5ef33d0d295a89d9d16bb81b0e3b0d5f70d6c875
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_app_badger: b87fc231847b03b92ce1412aa351842e7e97932f
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
@@ -24,12 +22,31 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>net.casimir-lab.frigoligo</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>frigoligo</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -47,9 +64,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>remote-notification</string>
-	</array>
 </dict>
 </plist>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,8 +2,10 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:frigoligo/pages/logconsole.dart';
+import 'package:frigoligo/pages/save.dart';
 import 'package:frigoligo/pages/session_details.dart';
 import 'package:frigoligo/pages/settings.dart';
+import 'package:frigoligo/providers/deeplinks.dart';
 import 'package:frigoligo/providers/logconsole.dart';
 import 'package:frigoligo/wallabag/wallabag.dart';
 import 'package:go_router/go_router.dart';
@@ -59,7 +61,7 @@ final _router = GoRouter(routes: [
   ),
   GoRoute(
     path: '/login',
-    builder: (context, state) => const LoginPage(),
+    builder: (context, state) => LoginPage(initial: state.uri.queryParameters),
   ),
   GoRoute(
     path: '/settings',
@@ -92,6 +94,10 @@ final _router = GoRouter(routes: [
       );
     },
   ),
+  GoRoute(
+    path: '/save',
+    builder: (context, state) => const SavePage(),
+  ),
 ]);
 
 class MyApp extends StatelessWidget {
@@ -99,11 +105,36 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => SettingsProvider(namespace: kDebugMode ? 'debug' : null),
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (_) =>
+              SettingsProvider(namespace: kDebugMode ? 'debug' : null),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => DeeplinksProvider(_router.configuration),
+          lazy: false,
+        ),
+      ],
       builder: (context, child) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          final deeplinks = context.read<DeeplinksProvider>();
+          if (!deeplinks.isListening) {
+            deeplinks.listen((linkType, uri) {
+              switch (linkType) {
+                case Deeplink.login:
+                  _router.go(uri.toString());
+                case Deeplink.save:
+                  _router.push(uri.toString());
+                default:
+              }
+            });
+          }
+        });
+
         final themeMode = context
             .select((SettingsProvider settings) => settings[Sk.themeMode]);
+
         return MaterialApp.router(
           routerConfig: _router,
           title: 'Frigoligo',

--- a/lib/pages/article.dart
+++ b/lib/pages/article.dart
@@ -196,7 +196,7 @@ class _ArticlePageState extends State<ArticlePage> {
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Text(article.domainName!),
+              Text(article.domainName ?? article.url),
               const Text(' - '),
               const Icon(Icons.timer_outlined),
               Text('${article.readingTime} min'),

--- a/lib/pages/login.dart
+++ b/lib/pages/login.dart
@@ -166,10 +166,15 @@ class _LoginPageState extends State<LoginPage> {
                   setState(() => _gotAnError = true);
                   if (e is WallabagError) {
                     _log.warning('authentication failed', e.message);
-                    showOkAlertDialog(context: context, message: e.message);
+                    if (context.mounted) {
+                      showOkAlertDialog(context: context, message: e.message);
+                    }
                   } else {
                     _log.severe('unexpected error', e);
-                    showOkAlertDialog(context: context, message: e.toString());
+                    if (context.mounted) {
+                      showOkAlertDialog(
+                          context: context, message: e.toString());
+                    }
                   }
                 }
               }

--- a/lib/pages/login_forms/server_form.dart
+++ b/lib/pages/login_forms/server_form.dart
@@ -5,10 +5,12 @@ import 'package:frigoligo/wallabag/utils.dart';
 import 'validators.dart';
 
 class ServerForm extends StatefulWidget {
-  const ServerForm({super.key, required this.stateKey, this.onCheckChange});
+  const ServerForm(
+      {super.key, required this.stateKey, this.onCheckChange, this.initial});
 
   final GlobalKey<FormBuilderState> stateKey;
   final void Function(WallabagServerCheck?)? onCheckChange;
+  final String? initial;
 
   @override
   State<ServerForm> createState() => _ServerFormState();
@@ -82,6 +84,7 @@ class _ServerFormState extends State<ServerForm> {
                       ),
                       autocorrect: false,
                       onSubmitted: (_) => startValidationAndCheck(),
+                      initialValue: widget.initial,
                     ),
                     const SizedBox(height: 8.0),
                     ElevatedButton(

--- a/lib/pages/save.dart
+++ b/lib/pages/save.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class SavePage extends StatelessWidget {
+  const SavePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Save Page'),
+      ),
+      body: Center(
+        child: Text('Save Page'),
+      ),
+    );
+  }
+}

--- a/lib/pages/save.dart
+++ b/lib/pages/save.dart
@@ -1,17 +1,140 @@
+import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:flutter/material.dart';
+import 'package:frigoligo/models/article.dart';
+import 'package:frigoligo/wallabag/wallabag.dart';
+import 'package:go_router/go_router.dart';
 
-class SavePage extends StatelessWidget {
-  const SavePage({super.key});
+import '../models/db.dart';
+
+class SavePage extends StatefulWidget {
+  const SavePage({super.key, required this.url});
+
+  final String? url;
+
+  @override
+  State<SavePage> createState() => _SavePageState();
+}
+
+class _SavePageState extends State<SavePage> {
+  SaveStep step = SaveStep.pending;
+  int? savedArticleId;
+  String? errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+
+    if (widget.url == null) {
+      setState(() {
+        step = SaveStep.error;
+        errorMessage = 'No URL provided';
+      });
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _doSave());
+    }
+  }
+
+  Future<void> _doSave() async {
+    if (Uri.tryParse(widget.url!)?.host.isEmpty ?? true) {
+      final res = await showOkCancelAlertDialog(
+        context: context,
+        title: 'Dubious URL',
+        message:
+            'This URL does not look like one. Save it anyway?\n${widget.url}',
+        okLabel: 'Save it',
+      );
+      if (res == OkCancelResult.cancel) {
+        if (context.mounted) context.pop();
+        return;
+      }
+    } else {
+      print(Uri.parse(widget.url!).host);
+    }
+
+    try {
+      final entry = await WallabagInstance.get().createEntry(widget.url!);
+      final article = Article.fromWallabagEntry(entry);
+
+      final db = DB.get();
+      await db.writeTxn(() async => await db.articles.put(article));
+
+      setState(() {
+        step = SaveStep.success;
+        savedArticleId = article.id;
+      });
+    } catch (e) {
+      setState(() {
+        step = SaveStep.error;
+        if (e is WallabagError) {
+          errorMessage = e.message;
+        } else {
+          errorMessage = e.toString();
+        }
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Save Page'),
+        title: const Text('Save article'),
       ),
       body: Center(
-        child: Text('Save Page'),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: switch (step) {
+            SaveStep.pending => _buildPendingWidgets(),
+            SaveStep.success => _buildSuccessWidgets(),
+            SaveStep.error => _buildErrorWidgets(),
+          },
+        ),
       ),
     );
   }
+
+  List<Widget> _buildPendingWidgets() {
+    return [
+      Text(
+        widget.url.toString(),
+        style: Theme.of(context).textTheme.headlineSmall,
+      ),
+      const SizedBox(height: 16.0),
+      const CircularProgressIndicator.adaptive(),
+    ];
+  }
+
+  List<Widget> _buildSuccessWidgets() {
+    return [
+      Text(
+        'Article saved!',
+        style: Theme.of(context).textTheme.headlineSmall,
+      ),
+      const SizedBox(height: 16.0),
+      const Icon(Icons.check_circle_outline, size: 40),
+      const SizedBox(height: 16.0),
+      // TODO a preview card would be waaaay nicer
+      ElevatedButton(
+        onPressed: () => context.replace('/articles/$savedArticleId'),
+        child: const Text('View article'),
+      ),
+    ];
+  }
+
+  List<Widget> _buildErrorWidgets() {
+    return [
+      Text(
+        errorMessage!,
+        style: Theme.of(context).textTheme.headlineSmall,
+      ),
+      const SizedBox(height: 16.0),
+      const Icon(Icons.error_outline, size: 40),
+    ];
+  }
+}
+
+enum SaveStep {
+  pending,
+  success,
+  error,
 }

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -8,6 +8,7 @@ import 'package:provider/provider.dart';
 import 'package:settings_ui/settings_ui.dart';
 
 import '../constants.dart';
+import '../providers/deeplinks.dart';
 import '../providers/settings.dart';
 import '../services/wallabag.dart';
 
@@ -117,6 +118,25 @@ class SettingsPage extends StatelessWidget {
                   leading: const Icon(Icons.bug_report),
                   title: const Text('Log Console'),
                   onPressed: (context) => context.push('/logs'),
+                ),
+                SettingsTile(
+                  leading: const Icon(Icons.dataset_linked),
+                  title: const Text('Open a deeplink'),
+                  onPressed: (context) async {
+                    final urls = await showTextInputDialog(
+                        context: context,
+                        textFields: [
+                          const DialogTextField(
+                            hintText: 'URL',
+                            keyboardType: TextInputType.url,
+                            autocorrect: false,
+                          )
+                        ]);
+                    if (context.mounted && urls != null) {
+                      final uri = Uri.parse(urls.first);
+                      context.read<DeeplinksProvider>().receive(uri);
+                    }
+                  },
                 ),
               ],
             )

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -10,7 +10,6 @@ import 'package:settings_ui/settings_ui.dart';
 import '../constants.dart';
 import '../providers/settings.dart';
 import '../services/wallabag.dart';
-import 'session_details.dart';
 
 final _log = Logger('frigoligo.listing');
 

--- a/lib/providers/deeplinks.dart
+++ b/lib/providers/deeplinks.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'package:app_links/app_links.dart';
+import 'package:flutter/foundation.dart';
+import 'package:go_router/go_router.dart';
+import 'package:logging/logging.dart';
+
+final _log = Logger('deeplinks');
+
+class DeeplinksProvider extends ChangeNotifier {
+  final AppLinks _appLinks = AppLinks();
+  StreamSubscription? _appLinksSubscription;
+  final RouteConfiguration routeConfiguration;
+
+  DeeplinksProvider(this.routeConfiguration);
+
+  bool get isListening => _appLinksSubscription != null;
+
+  void listen(void Function(Deeplink, Uri) onData) {
+    assert(_appLinksSubscription == null);
+    _appLinksSubscription = _appLinks.allUriLinkStream.listen((uri) {
+      _log.info('trying to open $uri');
+      final matches = routeConfiguration.findMatch(uri.toString());
+      if (matches.isEmpty) return;
+      final linkType = switch (uri.pathSegments.first) {
+        'login' => Deeplink.login,
+        'save' => Deeplink.save,
+        _ => null,
+      };
+      if (linkType != null) {
+        _log.info('validated $linkType: $uri');
+        onData(linkType, uri);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _appLinksSubscription?.cancel();
+    super.dispose();
+  }
+}
+
+enum Deeplink {
+  login,
+  save,
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import app_links
 import dynamic_color
 import flutter_app_badger
 import isar_flutter_libs
@@ -18,6 +19,7 @@ import sqflite
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
   FlutterAppBadgerPlugin.register(with: registry.registrar(forPlugin: "FlutterAppBadgerPlugin"))
   IsarFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "IsarFlutterLibsPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,4 +1,6 @@
 PODS:
+  - app_links (1.0.0):
+    - FlutterMacOS
   - dynamic_color (0.0.2):
     - FlutterMacOS
   - flutter_app_badger (1.3.0):
@@ -30,6 +32,7 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
+  - app_links (from `Flutter/ephemeral/.symlinks/plugins/app_links/macos`)
   - dynamic_color (from `Flutter/ephemeral/.symlinks/plugins/dynamic_color/macos`)
   - flutter_app_badger (from `Flutter/ephemeral/.symlinks/plugins/flutter_app_badger/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
@@ -48,6 +51,8 @@ SPEC REPOS:
     - FMDB
 
 EXTERNAL SOURCES:
+  app_links:
+    :path: Flutter/ephemeral/.symlinks/plugins/app_links/macos
   dynamic_color:
     :path: Flutter/ephemeral/.symlinks/plugins/dynamic_color/macos
   flutter_app_badger:
@@ -74,6 +79,7 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
+  app_links: 4481ed4d71f384b0c3ae5016f4633aa73d32ff67
   dynamic_color: 2eaa27267de1ca20d879fbd6e01259773fb1670f
   flutter_app_badger: 55a64b179f8438e89d574320c77b306e327a1730
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -30,5 +30,16 @@
 	<string>NSApplication</string>
 	<key>NSUserNotificationAlertStyle</key>
 	<string>banner</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>net.casimir-lab.frigoligo</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>frigoligo</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.7"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "16725e716afd0634a5441654b1dda2b6c5557aa230884b5e1f41a5aa546a4cb6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.3"
   args:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   settings_ui: ^2.0.2
   flutter_app_badger: ^1.5.0
   go_router: ^10.0.0
+  app_links: ^3.4.3
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,12 +6,15 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <app_links/app_links_plugin_c_api.h>
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
 #include <isar_flutter_libs/isar_flutter_libs_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  AppLinksPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   DynamicColorPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DynamicColorPluginCApi"));
   IsarFlutterLibsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  app_links
   dynamic_color
   isar_flutter_libs
   share_plus


### PR DESCRIPTION
The app now receive all links using the custom scheme `frigoligo://`.

Supported links:
- `/login` with the ability to prefill the form fields
- `/save` a new page for article saving (~just a skeleton for now~ implemented in e15e59a1fb36ccd6b37ca804eaffa54b6fc8844e)

There is also a new screen in the advanced section in the settings that allow to input a link/path manually.