### PR TITLE
Persist pending remote sync actions until there are sent to the server

### DIFF
--- a/lib/models/db.dart
+++ b/lib/models/db.dart
@@ -6,6 +6,7 @@ import '../constants.dart';
 import 'app_log.dart';
 import 'article.dart';
 import 'article_scroll_position.dart';
+import 'remote_action.dart';
 
 typedef DBInstance = Isar;
 
@@ -18,7 +19,12 @@ class DB {
 
     final dir = await getApplicationDocumentsDirectory();
     _instance = await Isar.open(
-      [AppLogSchema, ArticleSchema, ArticleScrollPositionSchema],
+      [
+        AppLogSchema,
+        ArticleSchema,
+        ArticleScrollPositionSchema,
+        RemoteActionSchema,
+      ],
       directory: dir.path,
       name: 'frigoligo${devmode ? '-dev' : ''}',
     );

--- a/lib/models/remote_action.dart
+++ b/lib/models/remote_action.dart
@@ -1,0 +1,31 @@
+import 'dart:convert';
+
+import 'package:isar/isar.dart';
+
+import '../services/remote_sync_actions/base.dart';
+
+part 'remote_action.g.dart';
+
+@collection
+class RemoteAction {
+  RemoteAction();
+
+  Id? id;
+  DateTime? createdAt;
+  int? key;
+  String? className;
+  String? jsonParams;
+
+  factory RemoteAction.fromRSA(RemoteSyncAction action) {
+    return RemoteAction()
+      ..key = action.hashCode
+      ..createdAt = DateTime.now()
+      ..className = action.runtimeType.toString()
+      ..jsonParams = jsonEncode(action.params());
+  }
+
+  RemoteSyncAction toRSA() {
+    final json = jsonDecode(jsonParams!);
+    return RemoteSyncAction.fromParams(className!, json);
+  }
+}

--- a/lib/models/remote_action.g.dart
+++ b/lib/models/remote_action.g.dart
@@ -1,0 +1,923 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'remote_action.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+extension GetRemoteActionCollection on Isar {
+  IsarCollection<RemoteAction> get remoteActions => this.collection();
+}
+
+const RemoteActionSchema = CollectionSchema(
+  name: r'RemoteAction',
+  id: -3509153609314200287,
+  properties: {
+    r'className': PropertySchema(
+      id: 0,
+      name: r'className',
+      type: IsarType.string,
+    ),
+    r'createdAt': PropertySchema(
+      id: 1,
+      name: r'createdAt',
+      type: IsarType.dateTime,
+    ),
+    r'jsonParams': PropertySchema(
+      id: 2,
+      name: r'jsonParams',
+      type: IsarType.string,
+    ),
+    r'key': PropertySchema(
+      id: 3,
+      name: r'key',
+      type: IsarType.long,
+    )
+  },
+  estimateSize: _remoteActionEstimateSize,
+  serialize: _remoteActionSerialize,
+  deserialize: _remoteActionDeserialize,
+  deserializeProp: _remoteActionDeserializeProp,
+  idName: r'id',
+  indexes: {},
+  links: {},
+  embeddedSchemas: {},
+  getId: _remoteActionGetId,
+  getLinks: _remoteActionGetLinks,
+  attach: _remoteActionAttach,
+  version: '3.1.4',
+);
+
+int _remoteActionEstimateSize(
+  RemoteAction object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  {
+    final value = object.className;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.jsonParams;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  return bytesCount;
+}
+
+void _remoteActionSerialize(
+  RemoteAction object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeString(offsets[0], object.className);
+  writer.writeDateTime(offsets[1], object.createdAt);
+  writer.writeString(offsets[2], object.jsonParams);
+  writer.writeLong(offsets[3], object.key);
+}
+
+RemoteAction _remoteActionDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = RemoteAction();
+  object.className = reader.readStringOrNull(offsets[0]);
+  object.createdAt = reader.readDateTimeOrNull(offsets[1]);
+  object.id = id;
+  object.jsonParams = reader.readStringOrNull(offsets[2]);
+  object.key = reader.readLongOrNull(offsets[3]);
+  return object;
+}
+
+P _remoteActionDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readStringOrNull(offset)) as P;
+    case 1:
+      return (reader.readDateTimeOrNull(offset)) as P;
+    case 2:
+      return (reader.readStringOrNull(offset)) as P;
+    case 3:
+      return (reader.readLongOrNull(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _remoteActionGetId(RemoteAction object) {
+  return object.id ?? Isar.autoIncrement;
+}
+
+List<IsarLinkBase<dynamic>> _remoteActionGetLinks(RemoteAction object) {
+  return [];
+}
+
+void _remoteActionAttach(
+    IsarCollection<dynamic> col, Id id, RemoteAction object) {
+  object.id = id;
+}
+
+extension RemoteActionQueryWhereSort
+    on QueryBuilder<RemoteAction, RemoteAction, QWhere> {
+  QueryBuilder<RemoteAction, RemoteAction, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension RemoteActionQueryWhere
+    on QueryBuilder<RemoteAction, RemoteAction, QWhereClause> {
+  QueryBuilder<RemoteAction, RemoteAction, QAfterWhereClause> idEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterWhereClause> idNotEqualTo(
+      Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterWhereClause> idGreaterThan(
+      Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterWhereClause> idLessThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+}
+
+extension RemoteActionQueryFilter
+    on QueryBuilder<RemoteAction, RemoteAction, QFilterCondition> {
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      classNameIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'className',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      classNameIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'className',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      classNameEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'className',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      classNameGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'className',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      classNameLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'className',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      classNameBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'className',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      classNameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'className',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      classNameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'className',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      classNameContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'className',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      classNameMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'className',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      classNameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'className',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      classNameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'className',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      createdAtIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'createdAt',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      createdAtIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'createdAt',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      createdAtEqualTo(DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      createdAtGreaterThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      createdAtLessThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      createdAtBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'createdAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition> idIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'id',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      idIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'id',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition> idEqualTo(
+      Id? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition> idGreaterThan(
+    Id? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition> idLessThan(
+    Id? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition> idBetween(
+    Id? lower,
+    Id? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      jsonParamsIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'jsonParams',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      jsonParamsIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'jsonParams',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      jsonParamsEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'jsonParams',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      jsonParamsGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'jsonParams',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      jsonParamsLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'jsonParams',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      jsonParamsBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'jsonParams',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      jsonParamsStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'jsonParams',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      jsonParamsEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'jsonParams',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      jsonParamsContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'jsonParams',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      jsonParamsMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'jsonParams',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      jsonParamsIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'jsonParams',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      jsonParamsIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'jsonParams',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition> keyIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'key',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      keyIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'key',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition> keyEqualTo(
+      int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'key',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition>
+      keyGreaterThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'key',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition> keyLessThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'key',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterFilterCondition> keyBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'key',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+}
+
+extension RemoteActionQueryObject
+    on QueryBuilder<RemoteAction, RemoteAction, QFilterCondition> {}
+
+extension RemoteActionQueryLinks
+    on QueryBuilder<RemoteAction, RemoteAction, QFilterCondition> {}
+
+extension RemoteActionQuerySortBy
+    on QueryBuilder<RemoteAction, RemoteAction, QSortBy> {
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> sortByClassName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'className', Sort.asc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> sortByClassNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'className', Sort.desc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> sortByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> sortByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> sortByJsonParams() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'jsonParams', Sort.asc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy>
+      sortByJsonParamsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'jsonParams', Sort.desc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> sortByKey() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'key', Sort.asc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> sortByKeyDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'key', Sort.desc);
+    });
+  }
+}
+
+extension RemoteActionQuerySortThenBy
+    on QueryBuilder<RemoteAction, RemoteAction, QSortThenBy> {
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> thenByClassName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'className', Sort.asc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> thenByClassNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'className', Sort.desc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> thenByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> thenByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> thenByJsonParams() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'jsonParams', Sort.asc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy>
+      thenByJsonParamsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'jsonParams', Sort.desc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> thenByKey() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'key', Sort.asc);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QAfterSortBy> thenByKeyDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'key', Sort.desc);
+    });
+  }
+}
+
+extension RemoteActionQueryWhereDistinct
+    on QueryBuilder<RemoteAction, RemoteAction, QDistinct> {
+  QueryBuilder<RemoteAction, RemoteAction, QDistinct> distinctByClassName(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'className', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QDistinct> distinctByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'createdAt');
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QDistinct> distinctByJsonParams(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'jsonParams', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<RemoteAction, RemoteAction, QDistinct> distinctByKey() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'key');
+    });
+  }
+}
+
+extension RemoteActionQueryProperty
+    on QueryBuilder<RemoteAction, RemoteAction, QQueryProperty> {
+  QueryBuilder<RemoteAction, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<RemoteAction, String?, QQueryOperations> classNameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'className');
+    });
+  }
+
+  QueryBuilder<RemoteAction, DateTime?, QQueryOperations> createdAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'createdAt');
+    });
+  }
+
+  QueryBuilder<RemoteAction, String?, QQueryOperations> jsonParamsProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'jsonParams');
+    });
+  }
+
+  QueryBuilder<RemoteAction, int?, QQueryOperations> keyProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'key');
+    });
+  }
+}

--- a/lib/services/remote_sync_actions/articles.dart
+++ b/lib/services/remote_sync_actions/articles.dart
@@ -4,6 +4,12 @@ class RefreshArticlesAction extends RemoteSyncAction {
   const RefreshArticlesAction() : super('refreshArticles');
 
   @override
+  ActionParams params() => {};
+
+  factory RefreshArticlesAction.fromParams(ActionParams params) =>
+      const RefreshArticlesAction();
+
+  @override
   Future<void> execute(syncer) async {
     await syncer.wallabag!.incrementalRefresh(
       onProgress: (progress) => syncer.progressValue = progress,
@@ -15,6 +21,12 @@ class DeleteArticleAction extends RemoteSyncAction {
   const DeleteArticleAction(this.articleId) : super('deleteArticle:$articleId');
 
   final int articleId;
+
+  @override
+  ActionParams params() => {'articleId': articleId};
+
+  factory DeleteArticleAction.fromParams(ActionParams params) =>
+      DeleteArticleAction(params['articleId'] as int);
 
   @override
   Future<void> execute(syncer) async {
@@ -35,6 +47,22 @@ class EditArticleAction extends RemoteSyncAction {
   final bool? archive;
   final bool? starred;
   final List<String>? tags;
+
+  @override
+  ActionParams params() => {
+        'articleId': articleId,
+        'archive': archive,
+        'starred': starred,
+        'tags': tags,
+      };
+
+  factory EditArticleAction.fromParams(ActionParams params) =>
+      EditArticleAction(
+        params['articleId'] as int,
+        archive: params['archive'] as bool?,
+        starred: params['starred'] as bool?,
+        tags: (params['tags'] as List?)?.cast<String>(),
+      );
 
   @override
   Future<void> execute(syncer) async {

--- a/lib/services/remote_sync_actions/base.dart
+++ b/lib/services/remote_sync_actions/base.dart
@@ -1,4 +1,7 @@
 import '../remote_sync.dart';
+import 'articles.dart';
+
+typedef ActionParams = Map<String, dynamic>;
 
 abstract class RemoteSyncAction {
   const RemoteSyncAction(String key) : _key = key;
@@ -12,6 +15,15 @@ abstract class RemoteSyncAction {
   @override
   int get hashCode => _key.hashCode;
 
+  ActionParams params();
+
+  factory RemoteSyncAction.fromParams(String className, ActionParams params) {
+    if (!actionBuilderRegistry.containsKey(className)) {
+      throw Exception('unknown RemoteSyncAction: $className');
+    }
+    return actionBuilderRegistry[className]!(params);
+  }
+
   Future<void> execute(RemoteSyncer syncer);
 
   @override
@@ -19,3 +31,10 @@ abstract class RemoteSyncAction {
     return '$runtimeType[$_key]';
   }
 }
+
+// TODO could not find a way to do it in dart without importing the other file
+Map<String, RemoteSyncAction Function(ActionParams)> actionBuilderRegistry = {
+  'RefreshArticlesAction': RefreshArticlesAction.fromParams,
+  'DeleteArticleAction': DeleteArticleAction.fromParams,
+  'EditArticleAction': EditArticleAction.fromParams,
+};


### PR DESCRIPTION
The actions are now stored in the database and executed in the next synchronization.

There could be more polish like altering the local cache immediatly or collapsing composable actions but time will tell what's really needed.

Adresses #65.