### PR TITLE
Postpone the notification permission prompt as much as possible

### DIFF
--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -69,8 +69,14 @@ class SettingsPage extends ConsumerWidget {
                   initialValue: settings[Sk.appBadge],
                   onToggle: (value) {
                     final previous = settings[Sk.appBadge];
-                    if (previous != value) storage.updateAppBadge();
-                    return settings[Sk.appBadge] = value;
+                    if (previous && !value) {
+                      // enabled -> disabled
+                      storage.removeAppBadge();
+                    } else if (!previous && value) {
+                      // disabled -> enabled
+                      storage.updateAppBadge();
+                    }
+                    settings[Sk.appBadge] = value;
                   },
                 ),
               SettingsTile.switchTile(

--- a/lib/services/wallabag_storage.dart
+++ b/lib/services/wallabag_storage.dart
@@ -135,16 +135,21 @@ class WallabagStorage with ChangeNotifier {
   }
 
   Future<void> updateAppBadge() async {
-    if (!appBadgeSupported) return;
+    if (!appBadgeSupported || !settings[Sk.appBadge]) return;
 
     final unread =
         count(WQuery(state: StateFilter.unread, starred: StarredFilter.all));
-    if (unread == 0 || !settings[Sk.appBadge]) {
+    if (unread == 0) {
       return FlutterAppBadger.removeBadge();
     } else {
       _log.info('updating app badge to $unread');
       return FlutterAppBadger.updateBadgeCount(unread);
     }
+  }
+
+  Future<void> removeAppBadge() async {
+    if (!appBadgeSupported) return;
+    return FlutterAppBadger.removeBadge();
   }
 
   Future<void> clearArticles({bool keepPositions = true}) async {


### PR DESCRIPTION
Instead of aggressively welcoming new user with a scary dialog.