### PR TITLE
Listing screen tweaks

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -281,7 +281,7 @@ class _MainContainerState extends ConsumerState<_MainContainer> {
       context.push('/articles/$articleId');
     }
 
-    return ListingPage(onItemSelect: onItemSelect);
+    return ListingPage(onItemSelect: onItemSelect, showSelectedItem: false);
   }
 
   Widget _buildWideLayout() {

--- a/lib/pages/listing.dart
+++ b/lib/pages/listing.dart
@@ -45,6 +45,25 @@ class ListingPage extends ConsumerStatefulWidget {
 }
 
 class _ListingPageState extends ConsumerState<ListingPage> {
+  final ScrollController _scroller = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+
+    final articleId = ref.read(currentArticleProvider)?.id;
+    if (articleId != null) {
+      final query = ref.read(queryProvider);
+      final scrollToIndex =
+          context.read<WallabagStorage>().indexOf(articleId, query);
+      if (scrollToIndex != null) {
+        WidgetsBinding.instance!.addPostFrameCallback((_) {
+          _scroller.jumpTo(scrollToIndex * listingHeight);
+        });
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final storage = context.watch<WallabagStorage>();
@@ -87,6 +106,7 @@ class _ListingPageState extends ConsumerState<ListingPage> {
                   child: RefreshIndicator.adaptive(
                     onRefresh: doRefresh,
                     child: ListView.separated(
+                      controller: _scroller,
                       padding: const EdgeInsets.symmetric(vertical: 8.0),
                       itemBuilder: (context, index) {
                         final article = storage.index(index, query)!;

--- a/lib/pages/listing.dart
+++ b/lib/pages/listing.dart
@@ -33,10 +33,12 @@ class ListingPage extends ConsumerStatefulWidget {
     super.key,
     this.onItemSelect,
     this.withProgressIndicator = true,
+    this.showSelectedItem = true,
   });
 
   final void Function(int articleId)? onItemSelect;
   final bool withProgressIndicator;
+  final bool showSelectedItem;
 
   @override
   ConsumerState<ListingPage> createState() => _ListingPageState();
@@ -103,6 +105,7 @@ class _ListingPageState extends ConsumerState<ListingPage> {
                                 .change(article.id!);
                             widget.onItemSelect?.call(article.id!);
                           },
+                          showSelection: widget.showSelectedItem,
                         );
                       },
                       separatorBuilder: (context, index) => const Divider(),
@@ -194,10 +197,16 @@ class _TitleWidgetState extends ConsumerState<TitleWidget> {
 }
 
 class ArticleListItem extends ConsumerWidget {
-  const ArticleListItem({super.key, required this.article, this.onTap});
+  const ArticleListItem({
+    super.key,
+    required this.article,
+    this.onTap,
+    required this.showSelection,
+  });
 
   final Article article;
   final void Function(Article)? onTap;
+  final bool showSelection;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -208,7 +217,9 @@ class ArticleListItem extends ConsumerWidget {
     final selectedId = ref.watch(currentArticleProvider)?.id;
 
     return Ink(
-      color: selectedId == article.id ? Theme.of(context).hoverColor : null,
+      color: showSelection && selectedId == article.id
+          ? Theme.of(context).highlightColor
+          : null,
       child: SizedBox(
         height: listingHeight,
         child: InkWell(

--- a/lib/providers/query.dart
+++ b/lib/providers/query.dart
@@ -5,7 +5,7 @@ import '../services/wallabag_storage.dart';
 
 part 'query.g.dart';
 
-@riverpod
+@Riverpod(keepAlive: true)
 class Query extends _$Query {
   @override
   WQuery build() => WQuery(state: StateFilter.unread);

--- a/lib/providers/query.g.dart
+++ b/lib/providers/query.g.dart
@@ -6,11 +6,11 @@ part of 'query.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$queryHash() => r'6b9a2ab0ba4ce26d267e5c74a617a6228307582f';
+String _$queryHash() => r'6b5bd2980c3ca9b40800a7a4c6455aa6766ff30f';
 
 /// See also [Query].
 @ProviderFor(Query)
-final queryProvider = AutoDisposeNotifierProvider<Query, WQuery>.internal(
+final queryProvider = NotifierProvider<Query, WQuery>.internal(
   Query.new,
   name: r'queryProvider',
   debugGetCreateSourceHash:
@@ -19,6 +19,6 @@ final queryProvider = AutoDisposeNotifierProvider<Query, WQuery>.internal(
   allTransitiveDependencies: null,
 );
 
-typedef _$Query = AutoDisposeNotifier<WQuery>;
+typedef _$Query = Notifier<WQuery>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/services/wallabag_storage.dart
+++ b/lib/services/wallabag_storage.dart
@@ -89,8 +89,17 @@ class WallabagStorage with ChangeNotifier {
 
   Article? index(int n, WQuery wq) {
     if (n < 0 || n >= count(wq)) return null;
-    var ids = _buildQuery(wq, sort: '-createdAt', property: 'id').findAllSync();
+    final ids =
+        _buildQuery(wq, sort: '-createdAt', property: 'id').findAllSync();
     return db.articles.getSync(ids[n])!;
+  }
+
+  int? indexOf(int articleId, WQuery wq) {
+    if (articleId <= 0) return null;
+    final ids =
+        _buildQuery(wq, sort: '-createdAt', property: 'id').findAllSync();
+    final index = ids.indexOf(articleId);
+    return index >= 0 ? index : null;
   }
 
   int count(WQuery wq) => _buildQuery(wq).countSync();


### PR DESCRIPTION
- Show the current selection on splitted layouts.
- Prevent the filters values to reset on some interactions.
- Keep the current selection on screen when rebuilding the listing.