### PR TITLE
Update appimagetool which can run in any linux

### DIFF
--- a/.github/workflows/build_and_upload.yml
+++ b/.github/workflows/build_and_upload.yml
@@ -184,7 +184,7 @@ jobs:
         working-directory: ./appimage
       - name: Build AppImage
         run: |
-          wget -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+          wget -q "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
           chmod +x appimagetool-x86_64.AppImage
           ./appimagetool-x86_64.AppImage Frigoligo.AppDir $ARTIFACT
         working-directory: ./appimage


### PR DESCRIPTION
With new tool, which uses [type2-runtime](https://github.com/AppImage/type2-runtime) app can be used in non-glibc systems like Alpine or Chimera 