### PR TITLE
fix(wallabag): allow null values in non-null published_by field

### DIFF
--- a/lib/wallabag/models/entry.dart
+++ b/lib/wallabag/models/entry.dart
@@ -61,7 +61,7 @@ class WallabagEntry {
   @JsonKey(name: 'published_at')
   final DateTime? publishedAt;
   @JsonKey(name: 'published_by')
-  final List<String>? publishedBy;
+  final List<String?>? publishedBy;
 
   // user data
   @JsonKey(name: 'user_id')

--- a/lib/wallabag/models/entry.g.dart
+++ b/lib/wallabag/models/entry.g.dart
@@ -42,7 +42,7 @@ WallabagEntry _$WallabagEntryFromJson(Map<String, dynamic> json) =>
           ? null
           : DateTime.parse(json['published_at'] as String),
       (json['published_by'] as List<dynamic>?)
-          ?.map((e) => e as String)
+          ?.map((e) => e as String?)
           .toList(),
       (json['user_id'] as num).toInt(),
       json['user_name'] as String,


### PR DESCRIPTION
It should be and (is considered?) an illegal value but exists for some users and that break the synchronization with the server.

It doesn't seem to be a bug in wallabag but the their data importer doesn't validate the data before importing (at least for the Omnivore importer).

Fixes #266 