### PR TITLE
refactor(settings): change how enum values are handled

### DIFF
--- a/lib/providers/settings.dart
+++ b/lib/providers/settings.dart
@@ -7,14 +7,34 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:universal_platform/universal_platform.dart';
 
+import '../app_info.dart';
 import 'ios/settings_syncer.dart';
 
 part 'settings.g.dart';
 
 final _log = Logger('settings');
 
+abstract class Codec<T> {
+  String encode(T object);
+  T decode(String raw);
+}
+
+class EnumCodec<T extends Enum> implements Codec<T> {
+  const EnumCodec(this.values);
+
+  final List<T> values;
+
+  @override
+  String encode(T object) => object.name;
+
+  @override
+  T decode(String raw) => values.firstWhere((it) => it.name == raw);
+}
+
 @riverpod
 class Settings extends _$Settings {
+  static const _versionKey = '_version';
+
   static Language? initialLocaleOverride;
   static String? namespace = kDebugMode ? 'debug' : null;
   static late SharedPreferences _prefs;
@@ -24,17 +44,21 @@ class Settings extends _$Settings {
   }
 
   Settings() {
+    _currentVersion = int.parse(AppInfo.data.buildNumber);
     if (UniversalPlatform.isIOS) {
       _syncer = SettingsSyncer(this);
     }
 
-    if (initialLocaleOverride != null) {
-      _log.info('initial locale override: $initialLocaleOverride');
-      set(Sk.language, initialLocaleOverride);
-      initialLocaleOverride = null;
-    }
+    _migrateVersion().then((_) {
+      if (initialLocaleOverride != null) {
+        _log.info('initial locale override: $initialLocaleOverride');
+        set(Sk.language, initialLocaleOverride);
+        initialLocaleOverride = null;
+      }
+    });
   }
 
+  late int _currentVersion;
   SettingsSyncer? _syncer;
 
   @override
@@ -46,24 +70,17 @@ class Settings extends _$Settings {
 
   dynamic get(Sk skey) {
     final key = _k(skey.key);
-    if (skey.items != null) {
-      final index = _prefs.getInt(_k(skey.key));
-      if (index == null) return skey.initial;
-      return skey.items![index];
-    }
-
     switch (skey.initial) {
       case bool _:
       case double _:
       case int _:
       case String _:
         return _prefs.get(key) ?? skey.initial;
-      case List<String> _:
-        return _prefs.getStringList(key);
       default:
         final raw = _prefs.getString(key);
         if (raw == null) return skey.initial;
-        return jsonDecode(raw);
+        final codec = skey.codec;
+        return codec != null ? codec.decode(raw) : jsonDecode(raw);
     }
   }
 
@@ -85,11 +102,9 @@ class Settings extends _$Settings {
         return _prefs.setInt(key, i);
       case String s:
         return _prefs.setString(key, s);
-      case List<String> ss:
-        return _prefs.setStringList(key, ss);
       default:
-        if (value case Enum e) return _prefs.setInt(key, e.index);
-        return _prefs.setString(key, jsonEncode(value));
+        final raw = skey.codec?.encode(value) ?? jsonEncode(value);
+        return _prefs.setString(key, raw);
     }
   }
 
@@ -105,23 +120,61 @@ class Settings extends _$Settings {
     ref.invalidateSelf();
     return ret;
   }
+
+  Future<void> _migrateVersion() async {
+    final oldVersion = _prefs.getInt(_k(_versionKey)) ?? 0;
+    if (oldVersion == _currentVersion) return;
+
+    var migrated = false;
+
+    if (oldVersion < 37) {
+      final langIndex = _prefs.getInt(_k(Sk.language.key));
+      if (langIndex != null) {
+        final oldLangOrder = [
+          Language.system,
+          Language.de,
+          Language.en,
+          Language.fr,
+          Language.gl,
+          Language.ptBR,
+          Language.zh,
+          Language.zhHant,
+          Language.ru,
+          Language.eo,
+        ];
+        _setValue(Sk.language, oldLangOrder[langIndex]);
+        migrated = true;
+      }
+
+      final themeIndex = _prefs.getInt(_k(Sk.themeMode.key));
+      if (themeIndex != null) {
+        _setValue(Sk.themeMode, ThemeMode.values[themeIndex]);
+        migrated = true;
+      }
+    }
+
+    if (migrated) {
+      _log.info('migrated settings from $oldVersion to $_currentVersion');
+      _prefs.setInt(_k(_versionKey), _currentVersion);
+    }
+  }
 }
 
 // Settings Keys
 enum Sk {
   appBadge('appBadge', false),
-  language('locale', Language.system, Language.values),
+  language('locale', Language.system, EnumCodec(Language.values)),
   selectedArticleId('selectedArticleId', -1),
   readingSettings('readingSettings', Object()),
   tagSaveEnabled('tagSaveEnabled', false),
   tagSaveLabel('tagSaveLabel', 'inbox'),
-  themeMode('themeMode', ThemeMode.system, ThemeMode.values);
+  themeMode('themeMode', ThemeMode.system, EnumCodec(ThemeMode.values));
 
-  const Sk(this._key, this.initial, [this.items]);
+  const Sk(this._key, this.initial, [this.codec]);
 
   final String _key;
   final Object initial;
-  final List<Object>? items;
+  final Codec? codec;
 
   String get key => 'settings.$_key';
 }

--- a/lib/providers/settings.g.dart
+++ b/lib/providers/settings.g.dart
@@ -6,7 +6,7 @@ part of 'settings.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$settingsHash() => r'4bba23d168940678ffda53e831e7fe2a6c09d8be';
+String _$settingsHash() => r'0eab150b2e25cfd3e8a7a983bd344bc86908b0b6';
 
 /// See also [Settings].
 @ProviderFor(Settings)


### PR DESCRIPTION
The previous method was based on ordered values and only allowed to append new values to the enum. The new method is not order sensitive anymore.