### PR TITLE
refactor(remotesync): prune remote actions after sync instead of a clear

### DIFF
--- a/lib/data/repositories/remote_action_repository.dart
+++ b/lib/data/repositories/remote_action_repository.dart
@@ -46,4 +46,19 @@ class RemoteActionRepositoryImpl implements RemoteActionRepository {
       return RemoteAction.fromParams(row.className, params);
     }).toList();
   }
+
+  @override
+  Future<void> pruneStaleActions(Set<int> presentArticleIds) async {
+    final actions = await getAllOrderedByCreation();
+    final staleKeys = actions
+        .where((a) {
+          final id = a.affectedArticleId;
+          return id != null && !presentArticleIds.contains(id);
+        })
+        .map((a) => a.hashCode)
+        .toSet();
+    if (staleKeys.isNotEmpty) {
+      await _localStorageService.remoteActions.deleteByKeys(staleKeys);
+    }
+  }
 }

--- a/lib/data/services/local/storage/database/database.dart
+++ b/lib/data/services/local/storage/database/database.dart
@@ -63,12 +63,15 @@ class DB extends $DB {
     },
   );
 
-  Future<void> clear({bool keepPositions = false}) {
+  Future<void> clear({
+    bool keepPendingActions = false,
+    bool keepPositions = false,
+  }) {
     return transaction(() async {
       await articles.deleteAll();
       await metadata.deleteAll();
+      if (!keepPendingActions) await remoteActions.deleteAll();
       if (!keepPositions) await articleScrollPositions.deleteAll();
-      await remoteActions.deleteAll();
     });
   }
 }

--- a/lib/data/services/local/storage/storage_service.dart
+++ b/lib/data/services/local/storage/storage_service.dart
@@ -387,9 +387,13 @@ class DatabaseManager {
 
   final DB _db;
 
-  /// Clears all data, optionally preserving scroll positions.
-  Future<void> clear({bool keepPositions = false}) =>
-      _db.clear(keepPositions: keepPositions);
+  Future<void> clear({
+    bool keepPendingActions = false,
+    bool keepPositions = false,
+  }) => _db.clear(
+    keepPendingActions: keepPendingActions,
+    keepPositions: keepPositions,
+  );
 }
 
 class MetadataManager {
@@ -436,6 +440,9 @@ class RemoteActionsManager {
 
   Future<int> delete(int key) =>
       _db.managers.remoteActions.filter((f) => f.key.equals(key)).delete();
+
+  Future<int> deleteByKeys(Set<int> keys) =>
+      _db.managers.remoteActions.filter((f) => f.key.isIn(keys)).delete();
 
   Future<void> clear() => _db.managers.remoteActions.delete();
 

--- a/lib/domain/repositories.dart
+++ b/lib/domain/repositories.dart
@@ -89,4 +89,6 @@ abstract class RemoteActionRepository {
   Future<bool> exists(RemoteAction action);
   Future<int> count();
   Future<List<RemoteAction>> getAllOrderedByCreation();
+
+  Future<void> pruneStaleActions(Set<int> presentArticleIds);
 }

--- a/lib/domain/sync/remote_actions.dart
+++ b/lib/domain/sync/remote_actions.dart
@@ -45,6 +45,9 @@ abstract class RemoteAction with EquatableMixin {
     return '${type.name}:$values';
   }
 
+  /// The article this action targets or null for article-independent actions.
+  int? get affectedArticleId => null;
+
   /// Parameters used when serializing the action. These are stored in DB until
   /// the action is executed.
   ActionParams get params;
@@ -116,8 +119,11 @@ class RefreshArticlesAction extends RemoteAction {
     _log.info('starting refresh with since=${sinceDT?.toIso8601String()}');
 
     if (since == null) {
-      await storage.database.clear(keepPositions: true);
-      _log.info('cleared the local cache (articles and pending actions)');
+      await storage.database.clear(
+        keepPendingActions: true,
+        keepPositions: true,
+      );
+      _log.info('cleared the local cache');
 
       final articlesStream = api.listArticles(
         since: sinceDT,
@@ -162,6 +168,9 @@ class DeleteArticleAction extends RemoteAction {
   final int articleId;
 
   @override
+  int? get affectedArticleId => articleId;
+
+  @override
   ActionParams get params => {'articleId': articleId};
 
   factory DeleteArticleAction.fromParams(ActionParams params) =>
@@ -191,6 +200,9 @@ class EditArticleAction extends RemoteAction {
   final bool? archived;
   final bool? starred;
   final List<String>? tags;
+
+  @override
+  int? get affectedArticleId => articleId;
 
   @override
   ActionParams get params => {
@@ -267,6 +279,9 @@ class RefetchArticleAction extends RemoteAction {
     : super(RemoteActionType.refetchArticle);
 
   final int articleId;
+
+  @override
+  int? get affectedArticleId => articleId;
 
   @override
   ActionParams get params => {'articleId': articleId};

--- a/lib/domain/sync/sync_manager.dart
+++ b/lib/domain/sync/sync_manager.dart
@@ -240,6 +240,9 @@ class SyncManager {
         );
         await _refreshAction.execute(api, _localStorageService, _setProgress);
 
+        final articleIds = await _localStorageService.articles.getAllIds();
+        await _remoteActionRepository.pruneStaleActions(articleIds);
+
         if (api is WithReadProgress) {
           _log.info('syncing read progress');
           _setProgress(null);

--- a/test/domain/sync/remote_actions_test.dart
+++ b/test/domain/sync/remote_actions_test.dart
@@ -84,6 +84,35 @@ void main() {
       expect(actionStr.contains(action.runtimeType.toString()), true);
       expect(actionStr.contains(action.value), true);
     });
+
+    group('affectedArticleId', () {
+      test('RefreshArticlesAction returns null', () {
+        expect(const RefreshArticlesAction().affectedArticleId, isNull);
+      });
+
+      test('DeleteArticleAction returns articleId', () {
+        expect(const DeleteArticleAction(123).affectedArticleId, 123);
+      });
+
+      test('EditArticleAction returns articleId', () {
+        expect(const EditArticleAction(456).affectedArticleId, 456);
+      });
+
+      test('SaveArticleAction returns null', () {
+        expect(
+          SaveArticleAction(Uri.parse('https://example.com')).affectedArticleId,
+          isNull,
+        );
+      });
+
+      test('RefetchArticleAction returns articleId', () {
+        expect(const RefetchArticleAction(789).affectedArticleId, 789);
+      });
+
+      test('NoopAction returns null', () {
+        expect(const NoopAction('test').affectedArticleId, isNull);
+      });
+    });
   });
 
   group('RefreshArticlesAction', () {

--- a/test/domain/sync/sync_manager_test.dart
+++ b/test/domain/sync/sync_manager_test.dart
@@ -387,6 +387,48 @@ void main() {
     });
   });
 
+  group('action preservation across resyncs', () {
+    test(
+      'SaveArticleAction survives database clear with keepPendingActions',
+      () async {
+        await syncManager.addAction(
+          SaveArticleAction(Uri.parse('https://example.com')),
+        );
+        expect(await syncManager.getPendingCount(), 1);
+
+        await storage.database.clear(keepPendingActions: true);
+
+        expect(await syncManager.getPendingCount(), 1);
+        final actions = await remoteActionRepository.getAllOrderedByCreation();
+        expect(actions.single, isA<SaveArticleAction>());
+      },
+    );
+
+    test(
+      'EditArticleAction for deleted article is pruned after resync',
+      () async {
+        await syncManager.addAction(
+          const EditArticleAction(999, archived: true),
+        );
+
+        await remoteActionRepository.pruneStaleActions({1, 2});
+
+        expect(await syncManager.getPendingCount(), 0);
+      },
+    );
+
+    test(
+      'EditArticleAction for existing article is preserved after resync',
+      () async {
+        await syncManager.addAction(const EditArticleAction(1, archived: true));
+
+        await remoteActionRepository.pruneStaleActions({1, 2});
+
+        expect(await syncManager.getPendingCount(), 1);
+      },
+    );
+  });
+
   group('read progress sync', () {
     test(
       'should not attempt read progress sync when withFinalRefresh is false',


### PR DESCRIPTION
Change the dumb "delete all actions" to a more subtil "delete all actions about unknown articles".

As a side-effect, it should fix an edge case involving an authentication error and the loss of an URL to save.